### PR TITLE
Add ModificationType enum and version id, rename MsgDeleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ This repository is part of the source code of Wire. You can find more informatio
 You can find the published source code at [github.com/wireapp/wire](https://github.com/wireapp/wire). 
 
 For licensing information, see the attached LICENSE file and the list of third-party licenses at [wire.com/legal/licenses/](https://wire.com/legal/licenses/).
+
+### generic-message-proto
+
+This repository contains the protobuf specifications used in Wire™.
+
+#### Editing a message
+
+If the content of a previously sent message should be edited, a generic message of type `MessageEdit` has to be sent. It should reference the new content (for now only type `Text` can be edited) as well as the nonce of the message it is replacing. If an edit message is received which is referencing a non existent nonce it should be discarded.

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -14,8 +14,10 @@ message GenericMessage {
     ClientAction clientAction = 9;
     Calling calling = 10;
     Asset asset = 11;
-    MsgDeleted deleted = 12;
+    MessageHide hidden = 12;
     Location location = 13;
+    MessageDelete deleted = 14;
+    MessageEdit edited = 15;
   }
 }
 
@@ -75,9 +77,20 @@ message Cleared {
   required int64 cleared_timestamp = 2;
 }
 
-message MsgDeleted {
+message MessageHide {
   required string conversation_id = 1;
   required string message_id = 2;
+}
+
+message MessageDelete {
+  required string message_id = 1;
+}
+
+message MessageEdit {
+  required string replacing_message_id = 1;
+  oneof content {
+    Text text = 2;
+  }
 }
 
 message Location {


### PR DESCRIPTION
This PR adds a new `ModificationType` enum to the spec. If a message needs to be edited or deleted (on all devices), the optional `modification` field needs to be set and the message. 
We introduced a new field `version_id` which should be set to a time based UUID when inserting a message as well as when applying a modification. Updates to messages (like adding a link preview for example) are only valid if they share the same `version_id` as the original message. Using the `version_id` we can avoid race conditions, for example when a message containing a link gets edited before the link preview was fetched and sent, which then might no longer be the correct preview. No `version_id` should always be considered the oldest version to keep compatibility with older clients.