### PR TITLE
Add confirmation message for read and delivered

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Message sent to recall previously sent message, can be only sent by original aut
 If the content of a previously sent message should be edited, a generic message of type `MessageEdit` has to be sent.
 It should reference the new content (for now only type `Text` can be edited) as well as the nonce of the message it is replacing. If an edit message is received which is referencing a non existent nonce it should be discarded.
 
+### Confirmation
+If the reception of a previously sent message should be confirmed, a generic message of type `Confirmation` has to be sent. It should reference the message to be confirmed. Currently the confirmation comes in two flavours: `Read` and `Delivered`.
+
 ### Location
 Location sharing message, contains GPS coordinates (latitude and longitude) and optional location name string.
 

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -18,6 +18,7 @@ message GenericMessage {
     Location location = 13;
     MessageDelete deleted = 14;
     MessageEdit edited = 15;
+	Confirmation confirmation = 16;
   }
 }
 
@@ -90,6 +91,18 @@ message MessageEdit {
   required string replacing_message_id = 1;
   oneof content {
     Text text = 2;
+  }
+}
+
+message Confirmation {
+  enum ConfirmationType {
+    DELIVERED = 0;
+    READ = 1;
+  }
+  
+  required string message_id = 1;
+  oneof content {
+    ConfirmationType type = 2;
   }
 }
 

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -18,7 +18,7 @@ message GenericMessage {
     Location location = 13;
     MessageDelete deleted = 14;
     MessageEdit edited = 15;
-	Confirmation confirmation = 16;
+    Confirmation confirmation = 16;
   }
 }
 
@@ -95,15 +95,13 @@ message MessageEdit {
 }
 
 message Confirmation {
-  enum ConfirmationType {
+  enum Type {
     DELIVERED = 0;
     READ = 1;
   }
   
   required string message_id = 1;
-  oneof content {
-    ConfirmationType type = 2;
-  }
+  required Type type = 2;
 }
 
 message Location {


### PR DESCRIPTION
We are adding a `Confirmation` message to confirm the delivery or (maybe in the future) reading of a message. The `Confirmation` message has a reference to the message to be confirmed.