### PR TITLE
Add `expire_after_millis` field to GenericMessage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ Protocol definition for generic messages.
 
 `GenericMessage` is supposed to be used in client messages ('client-message-add' event) and in OTR encrypted messages. Once E2EE is released client messages will no longer be used.
 
-`GenericMessage` contains message id and specific message content (`oneOf`)
+`GenericMessage` contains:
+ - message id 
+ - specific message content (`oneOf`)
+ - optional expiration delay (for ephemeral messages)
 
 ## Message Id
 `MessageId` field is client generated identifier of a message this `GenericMessage` relates to, it should be used by all clients to correlate message updates. This is **not** unique event id, there may (and will) be several `GenericMessage` events with the same `messageId`, each `GenericMessage` provides part of final message or some update to it.

--- a/android/build.sbt
+++ b/android/build.sbt
@@ -2,7 +2,7 @@ import com.github.os72.protocjar.Protoc.runProtoc
 
 name := "generic-message-proto"
 organization := "com.wire"
-version := "1.17.0"
+version := "1.18.0"
 crossPaths := false
 scalaVersion := "2.11.8"
 

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -20,6 +20,7 @@ message GenericMessage {
     Confirmation confirmation = 16;
     Reaction reaction = 17;
   }
+  optional int64 expire_after_millis = 18;
 }
 
 message Text {


### PR DESCRIPTION
This filed will be used for ephemeral messages to set their expiration delay.
By default all messages are not ephemeral (never expire), if this field is set then messages should be automatically removed after given time (in millis).