### PR TITLE
Add source of asset to asset metadata

### DIFF
--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -147,6 +147,8 @@ message Asset {
       VideoMetaData video = 5;
       AudioMetaData audio = 6;
     }
+    optional string source = 7; // link to source e.g. http://giphy.com/234245
+    optional string caption = 8; // caption of the asset, e.g. "dog" for a Giphy "dog" search result
   }
 
   message Preview {


### PR DESCRIPTION
# Reason for this pull request
We want to move away from sending a separate text message to indicate the source of an asset. We'd rather embed the source in the asset message itself.
