### PR TITLE
Support confirmation of multiple message IDs.

### DIFF
--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -112,8 +112,9 @@ message Confirmation {
     READ = 1;
   }
 
-  required string message_id = 1;
-  required Type type = 2;
+  required Type   type = 2;
+  required string first_message_id = 1;
+  repeated string more_message_ids = 3;
 }
 
 message Location {


### PR DESCRIPTION
Instead of having to send confirmation messages one by one this commit
adds support for sending them in batches. In addition to the added
property `more_message_ids` the existing one `message_id` is renamed to
`first_message_id` to put the two properties semantically closer
together.