### PR TITLE
adds the encryption algorithm enum as optional

### DIFF
--- a/android/build.sbt
+++ b/android/build.sbt
@@ -2,7 +2,7 @@ import com.github.os72.protocjar.Protoc.runProtoc
 
 name := "generic-message-proto"
 organization := "com.wire"
-version := "1.18.0"
+version := "1.18.1"
 crossPaths := false
 scalaVersion := "2.11.8"
 

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -188,11 +188,11 @@ message Asset {
 
   message RemoteData {
     required bytes otr_key = 1;
-    required bytes sha256 = 2;
+    required bytes sha256 = 2; // obsolete but required for backward compatibility
     optional string asset_id = 3;
 //    optional bytes asset_token = 4; // deprecated - changed type to string
     optional string asset_token = 5;
-    optional EncryptionAlgorithm = 6;
+    optional EncryptionAlgorithm encryption = 6;
   }
 
   optional Original original = 1;
@@ -207,7 +207,7 @@ message Asset {
 // Actual message is encrypted with AES and sent as additional data
 message External {
   required bytes otr_key = 1;
-  optional bytes sha256 = 2;      // sha256 of ciphertext
+  optional bytes sha256 = 2;      // sha256 of ciphertext, obsolete but required for backward compatibility
   optional EncryptionAlgorithm encryption = 3;
 }
 

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -192,6 +192,7 @@ message Asset {
     optional string asset_id = 3;
 //    optional bytes asset_token = 4; // deprecated - changed type to string
     optional string asset_token = 5;
+    optional EncryptionAlgorithm = 6;
   }
 
   optional Original original = 1;
@@ -207,6 +208,7 @@ message Asset {
 message External {
   required bytes otr_key = 1;
   optional bytes sha256 = 2;      // sha256 of ciphertext
+  optional EncryptionAlgorithm encryption = 3;
 }
 
 message Reaction {
@@ -220,4 +222,9 @@ enum ClientAction {
 
 message Calling {
   required string content = 1;
+}
+
+enum EncryptionAlgorithm {
+  AES_CBC = 0;
+  AES_GCM = 1;
 }


### PR DESCRIPTION
If the field is missing from the message, it means we use the old algorithm (AES_CBC).