### PR TITLE
Making Protocol Buffers available on npmjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
+node_modules/
 target/

--- a/package.json
+++ b/package.json
@@ -1,11 +1,20 @@
 {
+  "dependencies": {
+    "protobufjs": "6.8.0"
+  },
   "description": "Protocol definition for generic messages.",
+  "files": [
+    "proto/messages.proto",
+    "web/index.d.ts",
+    "web/index.js"
+  ],
   "license": "GPL-3.0",
-  "main": "./proto",
-  "name": "wire-webapp-protocol-messaging",
+  "main": "web/index.js",
+  "name": "@wireapp/protocol-messaging",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wireapp/generic-message-proto.git"
   },
+  "types": "web/index.d.ts",
   "version": "1.19.0"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "lib": [
+      "DOM",
+      "ES6"
+    ],
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "outDir": "web",
+    "removeComments": true,
+    "rootDir": "web",
+    "sourceMap": false,
+    "target": "ES5"
+  },
+  "exclude": [
+    "dist/commonjs",
+    "node_modules"
+  ]
+}

--- a/web/index.d.ts
+++ b/web/index.d.ts
@@ -1,2 +1,0 @@
-import { Root } from 'protobufjs';
-export default function (): Promise<Root>;

--- a/web/index.d.ts
+++ b/web/index.d.ts
@@ -1,0 +1,2 @@
+import { Root } from 'protobufjs';
+export default function (): Promise<Root>;

--- a/web/index.js
+++ b/web/index.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var protobufjs_1 = require("protobufjs");
-function default_1() {
-    return protobufjs_1.load('../proto/messages.proto');
+function loadProtocolBuffers() {
+    return protobufjs_1.load(__dirname + "/../proto/messages.proto");
 }
-exports.default = default_1;
+module.exports = loadProtocolBuffers;

--- a/web/index.js
+++ b/web/index.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var protobufjs_1 = require("protobufjs");
+function default_1() {
+    return protobufjs_1.load('../proto/messages.proto');
+}
+exports.default = default_1;

--- a/web/index.ts
+++ b/web/index.ts
@@ -1,0 +1,5 @@
+import {load, Root} from 'protobufjs';
+
+export default function (): Promise<Root> {
+    return load('../proto/messages.proto');
+}

--- a/web/index.ts
+++ b/web/index.ts
@@ -1,5 +1,7 @@
 import {load, Root} from 'protobufjs';
 
-export default function (): Promise<Root> {
-    return load('../proto/messages.proto');
+function loadProtocolBuffers(): Promise<Root> {
+    return load(`${__dirname}/../proto/messages.proto`);
 }
+
+module.exports = loadProtocolBuffers;


### PR DESCRIPTION
The goal is to make our Protocol Buffers consumable for external modules. It's already possible through [Bower](https://bower.io/) (for Web Browser) but we also want to distribute a safe way of receiving our Protocol Buffers via [npmjs](https://www.npmjs.com/) (for applications built on Node.js). 

Therefore we need to reference `messages.proto` from code (`loadProtocolBuffers()`), otherwise the reference will be broken for external modules.

With this PR our `messages.proto` can be consumed as follows:

```javascript
const loadProtocolBuffers = require('@wireapp/protocol-messaging');

loadProtocolBuffers().then((buffers) => {
  console.log('Buffers', buffers);
});
```