### PR TITLE
[Draft] Allow marking conversation unread

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Describes user mentioned in text message. Contains `userId` and `userName`. User
 ### Knock
 
 ### LastRead
-Internal message, sent on self conversation to notify other clients (belonging to the same user) about messages being read in some conversation.
+Internal message, sent on self conversation to notify other clients (belonging to the same user) about messages being read in some conversation. Clients ignore the last read that is earlier than the current last read. To set the conversation to be unread until certain timestamp use `force_update` flag.
 
 ### Cleared
 Internal message, sent on self conversation to notify other clients about conversation being cleared.

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -95,6 +95,7 @@ message Mention {
 message LastRead {
   required string conversation_id = 1;
   required int64 last_read_timestamp = 2;
+  optional bool force_update = 3;
 }
 
 message Cleared {


### PR DESCRIPTION
# Abstract

The experimental feature to mark the conversations as unread to certain point in time, developed on the iOS client, seem to be requested by the power users and necessary for Wire to be the full-featured E-Mail replacement. It allows the users to mark unread the conversations that they are willing to revisit in the future due to lack of time or other reasons. In this PR we are adding the support for marking the conversations unread across the clients.

# The Problem

We discovered, that the clients are rightfully discarding the last read messages that are pointing to the timestamp that is already marked as read in the client's database for the given conversation. The reason to discard the timestamp in the past is for the cases when user is reading the conversations on two devices, hence the last read messages can be arriving out of sync. For the client there is no way to distinguish between the normal last read update from reading the conversation and the last read explicitly set by the user.

# Proposed solution

The updated message format is needed for the clients to understand that the message is setting the timestamp in the past by the user demand.

The clients would then have to distinguish between the normal last read and the new one and act accordingly:

1. For the old last read keep the existing logic.
2. For the new last read move the timestamp to the given value but do not re-show the push notifications.

# Status of the proposal

This is a draft proposal under discussion, please give your feedback.