### PR TITLE
Updated mentions message to include offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A user sends a generic message of type `Availability` if he wants to change his 
 Regular text message content, optionally including a list of mentioned users.
 
 #### Mention
-Describes user mentioned in text message. Contains `userId`, `start` and `end` offsets of the mention string in UTF16 characters. The offset is used to highlight mention text inside the message. 
+Describes user mentioned in text message. Contains `user_id`, `start` and `end` offsets of the mention string in UTF16 characters. The offset is used to highlight mention text inside the message. `user_id` is optional because to keep it backwards compatible when mentioning more than one user e.g. @everyone or @some_team. 
 
 ### Knock
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A user sends a generic message of type `Availability` if he wants to change his 
 Regular text message content, optionally including a list of mentioned users.
 
 #### Mention
-Describes user mentioned in text message. Contains `userId` and `userName`. User name should be the exact string that is used in text, in other words text content should contain following string: '@{userName}'. It can be used by receiving client to locate users in received text message.
+Describes user mentioned in text message. Contains `userId`, `start` and `end` offsets of the mention string in UTF16 characters. The offset is used to highlight mention text inside the message. 
 
 ### Knock
 

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -88,10 +88,11 @@ message Article {
 }
 
 message Mention {
-  required string user_id = 1;
+  // required string user_id = 1; // Deprecated it is optional now, use user_id = 3 instead
   // required string user_name = 2; // Deprecated
-  required int32 start = 3; // offset from beginning of the message counting in utf16 characters
-  required int32 end = 4; // offset from beginning of the message counting in utf16 characters
+  optional string user_id = 3;
+  required int32 start = 4; // offset from beginning of the message counting in utf16 characters
+  required int32 end = 5; // offset from beginning of the message counting in utf16 characters
 }
 
 message LastRead {

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -89,7 +89,9 @@ message Article {
 
 message Mention {
   required string user_id = 1;
-  required string user_name = 2;
+  // required string user_name = 2; // Deprecated
+  required int32 start = 3; // offset from beginning of the message counting in utf16 characters
+  required int32 end = 4; // offset from beginning of the message counting in utf16 characters
 }
 
 message LastRead {


### PR DESCRIPTION
Re-using existing `Mentions` message with changes:
* Deprecating unused `user_name` field 
* Added two offsets - `start` and `end`