### PR TITLE
Fix backwards compatibility with older clients

### DIFF
--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -92,7 +92,7 @@ message Mention {
   required int32 start = 1; // offset from beginning of the message counting in utf16 characters
   required int32 end = 2; // offset from beginning of the message counting in utf16 characters
   oneof mention_type {
-       string user_id = 3;
+    string user_id = 3;
   }
 }
 

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -50,7 +50,7 @@ message Text {
   required string content = 1;
   reserved 2; 
   repeated LinkPreview link_preview = 3;
-  repeated UserMention user_mentions = 4;
+  repeated Mention mentions = 4;
 }
 
 message Knock {
@@ -88,7 +88,7 @@ message Article {
   optional Asset image = 4;
 }
 
-message UserMention {
+message Mention {
   required int32 start = 1; // offset from beginning of the message counting in utf16 characters
   required int32 end = 2; // offset from beginning of the message counting in utf16 characters
   oneof mention_type {

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -89,9 +89,11 @@ message Article {
 }
 
 message Mention {
-  optional string user_id = 1;
-  required int32 start = 2; // offset from beginning of the message counting in utf16 characters
-  required int32 end = 3; // offset from beginning of the message counting in utf16 characters
+  required int32 start = 1; // offset from beginning of the message counting in utf16 characters
+  required int32 end = 2; // offset from beginning of the message counting in utf16 characters
+  oneof mention_type {
+       string user_id = 3;
+  }
 }
 
 message LastRead {

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -48,9 +48,9 @@ message Ephemeral {
 
 message Text {
   required string content = 1;
-  //repeated Mention mention = 2; // Deprecated, use Mention = 4
+  reserved 2; 
   repeated LinkPreview link_preview = 3;
-  repeated Mention mention = 4;
+  repeated UserMention user_mentions = 4;
 }
 
 message Knock {
@@ -88,7 +88,7 @@ message Article {
   optional Asset image = 4;
 }
 
-message Mention {
+message UserMention {
   required int32 start = 1; // offset from beginning of the message counting in utf16 characters
   required int32 end = 2; // offset from beginning of the message counting in utf16 characters
   oneof mention_type {

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -48,8 +48,9 @@ message Ephemeral {
 
 message Text {
   required string content = 1;
-  repeated Mention mention = 2;
+  //repeated Mention mention = 2; // Deprecated, use Mention = 4
   repeated LinkPreview link_preview = 3;
+  repeated Mention mention = 4;
 }
 
 message Knock {
@@ -88,11 +89,9 @@ message Article {
 }
 
 message Mention {
-  // required string user_id = 1; // Deprecated it is optional now, use user_id = 3 instead
-  // required string user_name = 2; // Deprecated
-  optional string user_id = 3;
-  required int32 start = 4; // offset from beginning of the message counting in utf16 characters
-  required int32 end = 5; // offset from beginning of the message counting in utf16 characters
+  optional string user_id = 1;
+  required int32 start = 2; // offset from beginning of the message counting in utf16 characters
+  required int32 end = 3; // offset from beginning of the message counting in utf16 characters
 }
 
 message LastRead {


### PR DESCRIPTION
The issue was that by removing a required fields `user_id` and `user_name` we broke backwards compatibility - old clients received `Mention` message without required fields set.

Note: I have removed extra fields from `Mention` because it's basically a new type of message now.