### PR TITLE
Less ambiguous mention

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     "postversion": "git push && git push --tags"
   },
   "types": "web/Protobuf.d.ts",
-  "version": "1.21.2"
+  "version": "1.21.5"
 }

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -90,7 +90,7 @@ message Article {
 
 message Mention {
   required int32 start = 1; // offset from beginning of the message counting in utf16 characters
-  required int32 end = 2; // offset from beginning of the message counting in utf16 characters
+  required int32 length = 2;
   oneof mention_type {
     string user_id = 3;
   }


### PR DESCRIPTION
Previous specification was ambiguous. Initial implementations already diverged pointing end to the last char part of the mention or the first char not part of the mention. Length should be less ambiguous and leave no room for interpretation.