### PR TITLE
fix: Set default LH status to 'unknown'

### DIFF
--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -265,5 +265,5 @@ enum EncryptionAlgorithm {
 enum LegalHoldStatus {
   UNKNOWN = 0;
   DISABLED = 0;
-  ENABLED = 2;  
+  ENABLED = 2;
 }

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -263,7 +263,7 @@ enum EncryptionAlgorithm {
 }
 
 enum LegalHoldStatus {
+  UNKNOWN = 0;
   DISABLED = 0;
-  ENABLED = 1;
-  UNKNOWN = 2;
+  ENABLED = 2;  
 }

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -53,13 +53,13 @@ message Text {
   repeated Mention mentions = 4;
   optional Quote quote = 5; // if this Text is part of a MessageEdit, this field is ignored
   optional bool expects_read_confirmation = 6 [default = false]; // whether the sender is expecting to receive a read confirmation
-  optional LegalHoldStatus legal_hold_status = 7; // whether this message was sent to legal hold
+  optional LegalHoldStatus legal_hold_status = 7 [default = UNKNOWN]; // whether this message was sent to legal hold
 }
 
 message Knock {
   required bool hot_knock = 1 [default = false];
   optional bool expects_read_confirmation = 2 [default = false]; // whether the sender is expecting to receive a read confirmation
-  optional LegalHoldStatus legal_hold_status = 3; // whether this message was sent to legal hold
+  optional LegalHoldStatus legal_hold_status = 3 [default = UNKNOWN]; // whether this message was sent to legal hold
 }
 
 message LinkPreview {
@@ -139,7 +139,7 @@ message Confirmation {
     READ = 1;
   }
 
-  required Type   type = 2;
+  required Type type = 2;
   required string first_message_id = 1;
   repeated string more_message_ids = 3;
 }
@@ -150,7 +150,7 @@ message Location {
   optional string name = 3; // location description/name
   optional int32 zoom = 4;  // google maps zoom level (check maps api documentation)
   optional bool expects_read_confirmation = 5 [default = false]; // whether the sender is expecting to receive a read confirmation
-  optional LegalHoldStatus legal_hold_status = 6; // whether this message was sent to legal hold
+  optional LegalHoldStatus legal_hold_status = 6 [default = UNKNOWN]; // whether this message was sent to legal hold
 }
 
 // deprecated in favour of Asset.Original.ImageMetaData
@@ -233,7 +233,7 @@ message Asset {
   }
   optional Preview preview = 5;
   optional bool expects_read_confirmation = 6 [default = false]; // whether the sender is expecting to receive a read confirmation
-  optional LegalHoldStatus legal_hold_status = 7; // whether this message was sent to legal hold
+  optional LegalHoldStatus legal_hold_status = 7 [default = UNKNOWN]; // whether this message was sent to legal hold
 }
 
 // Actual message is encrypted with AES and sent as additional data
@@ -246,7 +246,7 @@ message External {
 message Reaction {
   optional string emoji = 1; // some emoji reaction or the empty string to remove previous reaction(s)
   required string message_id = 2;
-  optional LegalHoldStatus legal_hold_status = 3; // whether this message was sent to legal hold
+  optional LegalHoldStatus legal_hold_status = 3 [default = UNKNOWN]; // whether this message was sent to legal hold
 }
 
 enum ClientAction {
@@ -265,4 +265,5 @@ enum EncryptionAlgorithm {
 enum LegalHoldStatus {
   DISABLED = 0;
   ENABLED = 1;
+  UNKNOWN = 2;
 }

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -264,6 +264,6 @@ enum EncryptionAlgorithm {
 
 enum LegalHoldStatus {
   UNKNOWN = 0;
-  DISABLED = 0;
+  DISABLED = 1;
   ENABLED = 2;
 }


### PR DESCRIPTION
## The Problem

We want to be able to know if a user turns on/off legal hold or if a user has a client that doesn't know about legal hold at all. The problem is that modern Protobuf libraries (introduced in Protobuf 2) will always render a default value to any optional flag (read [Optional Fields And Default Values](https://developers.google.com/protocol-buffers/docs/proto#optional)). In our context it means the following... When a client that knows about legal hold receives a message from a client which does not set a value for it (because it is old and doesn't know the property yet), then the modern client will automatically assign a default value (in our case "legal hold off") which makes it impossible to distinguish whether a client wants to turn legal hold off or does not know about it.

## Proposed solution

We will introduce another value (`UNKNOWN`) which will act as the default value for the `legal_hold_status` property. This is also a best practice suggested by the Profobuf Language Guide (see [Enumerations](https://developers.google.com/protocol-buffers/docs/proto#enum)).