### PR TITLE
Rename Button to MultipleChoiceButton

### DIFF
--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -33,12 +33,12 @@ message CompositeMessage {
   message Item {
       oneof content {
           Text text = 1;
-          Button button = 2;
+          MultipleChoiceButton multipleChoiceButton = 2;
       }
   }
 }
 
-message Button {
+message MultipleChoiceButton {
   required string text = 1;
   required string id = 2;
 }


### PR DESCRIPTION
I propose to rename the `message Button` to `message MultipleChoiceButton`. This will make it more clear how the buttons in the `CompositeMessage` should behave and allows us to add other buttons types in the future.