### PR TITLE
SignatureResponse

### DIFF
--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -24,7 +24,12 @@ message GenericMessage {
     Composite composite = 20;
     ButtonAction buttonAction = 21;
     ButtonActionConfirmation buttonActionConfirmation = 22;
+    SignatureResponse = 23;
   }
+}
+
+message SignatureResponse {
+  required string response_id = 1;
 }
 
 message Composite {


### PR DESCRIPTION
This message is intended for Secure Sign integration.
Response_id comes from `POST /signatures/request`