### PR TITLE
Add data transfer message between devices

### DIFF
--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -301,7 +301,7 @@ enum LegalHoldStatus {
   ENABLED = 2;
 }
 
-message DataTrasfer {
+message DataTransfer {
   optional TrackingIdentifier trackingIdentifier = 0;
 }
 

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -24,6 +24,7 @@ message GenericMessage {
     Composite composite = 20;
     ButtonAction buttonAction = 21;
     ButtonActionConfirmation buttonActionConfirmation = 22;
+    DataTransfer dataTransfer = 23; // client-side synchronization across devices of the same user
   }
 }
 
@@ -298,4 +299,12 @@ enum LegalHoldStatus {
   UNKNOWN = 0;
   DISABLED = 1;
   ENABLED = 2;
+}
+
+message DataTrasfer {
+  optional TrackingIdentifier trackingIdentifier = 0;
+}
+
+message TrackingIdentifier {
+  required string identifier = 0;
 }


### PR DESCRIPTION
This PR adds a message to synchronize some data across devices of the same user to "initialize" new devices with client-side data that we don't want to store on the backend.

At the moment, the only data transferred is an ID used for analytics purposes, but this lays the foundation to transfer other client-side secrets easily.