### PR TITLE
[Fix] Field numbers are not positive integers

### DIFF
--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -287,11 +287,11 @@ message Calling {
 }
 
 message DataTransfer {
-  optional TrackingIdentifier trackingIdentifier = 0;
+  optional TrackingIdentifier trackingIdentifier = 1;
 }
 
 message TrackingIdentifier {
-  required string identifier = 0;
+  required string identifier = 1;
 }
 
 // Enums have to come last because of an unresolved issue with jsdoc


### PR DESCRIPTION
## Issue

Compiling `messages.proto` fails.

## Cause

The field numbers for the newly added `DataTransfer` and `TrackingIdentifier` messages are not positive integers. This was reported by `protoc`:

```
messages.proto:290:52: Field numbers must be positive integers.
messages.proto:294:32: Field numbers must be positive integers.
```

## Solution

Set each field number to a positive integer.