### PR TITLE
Extend generic message fields to enable qualified user ids

### DIFF
--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -28,6 +28,16 @@ message GenericMessage {
   }
 }
 
+message QualifiedUser {
+  optional string id = 1;
+  optional string domain = 2;
+}
+
+message QualifiedConversation {
+  optional string id = 1;
+  optional string domain = 2;
+}
+
 message Composite {
   repeated Item items = 1;
   optional bool expects_read_confirmation = 2 [default = false];
@@ -135,9 +145,7 @@ message Mention {
     string user_id = 3;
   }
   // only optional to maintain backwards compatibility.
-  optional string federated_user_id = 4;
-  // only optional to maintain backwards compatibility
-  optional string federated_backend_domain = 5;
+  optional QualifiedUser qualified_user = 4;
 }
 
 message LastRead {
@@ -146,9 +154,7 @@ message LastRead {
   required string conversation_id = 1;
   required int64 last_read_timestamp = 2;
   // only optional to maintain backwards compatibility
-  optional string federated_conversation_id = 3;
-  // only optional to maintain backwards compatibility
-  optional string federated_backend_domain = 4;
+  optional QualifiedConversation qualified_conversation = 3;
 }
 
 message Cleared {
@@ -157,9 +163,7 @@ message Cleared {
   required string conversation_id = 1;
   required int64 cleared_timestamp = 2;
   // only optional to maintain backwards compatibility
-  optional string federated_conversation_id = 3;
-  // only optional to maintain backwards compatibility
-  optional string federated_backend_domain = 4;
+  optional QualifiedConversation qualified_conversation = 3;
 }
 
 message MessageHide {
@@ -168,9 +172,7 @@ message MessageHide {
   required string conversation_id = 1;
   required string message_id = 2;
   // only optional to maintain backwards compatibility
-  optional string federated_conversation_id = 3;
-  // only optional to maintain backwards compatibility
-  optional string federated_backend_domain = 4;
+  optional QualifiedConversation qualified_conversation = 3;
 }
 
 message MessageDelete {

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -129,23 +129,48 @@ message Mention {
   required int32 start = 1; // offset from beginning of the message counting in utf16 characters
   required int32 length = 2;
   oneof mention_type {
+    // deprecated. Should be set such that old clients always fail when looking
+    // up the user. Ideally, this should not be a problem, as a non-federation
+    // aware user should never be part of a federated conversation.
     string user_id = 3;
   }
+  // only optional to maintain backwards compatibility.
+  optional string federated_user_id = 4;
+  // only optional to maintain backwards compatibility
+  optional string federated_backend_domain = 5;
 }
 
 message LastRead {
+  // deprecated. Should be set such that old clients always fail when looking up
+  // the conversation.
   required string conversation_id = 1;
   required int64 last_read_timestamp = 2;
+  // only optional to maintain backwards compatibility
+  optional string federated_conversation_id = 3;
+  // only optional to maintain backwards compatibility
+  optional string federated_backend_domain = 4;
 }
 
 message Cleared {
+  // deprecated. Should be set such that old clients always fail when looking up
+  // the conversation.
   required string conversation_id = 1;
   required int64 cleared_timestamp = 2;
+  // only optional to maintain backwards compatibility
+  optional string federated_conversation_id = 3;
+  // only optional to maintain backwards compatibility
+  optional string federated_backend_domain = 4;
 }
 
 message MessageHide {
+  // deprecated. Should be set such that old clients always fail when looking up
+  // the conversation.
   required string conversation_id = 1;
   required string message_id = 2;
+  // only optional to maintain backwards compatibility
+  optional string federated_conversation_id = 3;
+  // only optional to maintain backwards compatibility
+  optional string federated_backend_domain = 4;
 }
 
 message MessageDelete {

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -29,13 +29,13 @@ message GenericMessage {
 }
 
 message QualifiedUser {
-  optional string id = 1;
-  optional string domain = 2;
+  required string id = 1;
+  required string domain = 2;
 }
 
 message QualifiedConversation {
-  optional string id = 1;
-  optional string domain = 2;
+  required string id = 1;
+  required string domain = 2;
 }
 
 message Composite {

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -145,7 +145,7 @@ message Mention {
     string user_id = 3;
   }
   // only optional to maintain backwards compatibility.
-  optional QualifiedUser qualified_user = 4;
+  optional QualifiedUser qualified_user_id = 4;
 }
 
 message LastRead {
@@ -154,7 +154,7 @@ message LastRead {
   required string conversation_id = 1;
   required int64 last_read_timestamp = 2;
   // only optional to maintain backwards compatibility
-  optional QualifiedConversation qualified_conversation = 3;
+  optional QualifiedConversation qualified_conversation_id = 3;
 }
 
 message Cleared {
@@ -163,7 +163,7 @@ message Cleared {
   required string conversation_id = 1;
   required int64 cleared_timestamp = 2;
   // only optional to maintain backwards compatibility
-  optional QualifiedConversation qualified_conversation = 3;
+  optional QualifiedConversation qualified_conversation_id = 3;
 }
 
 message MessageHide {
@@ -172,7 +172,7 @@ message MessageHide {
   required string conversation_id = 1;
   required string message_id = 2;
   // only optional to maintain backwards compatibility
-  optional QualifiedConversation qualified_conversation = 3;
+  optional QualifiedConversation qualified_conversation_id = 3;
 }
 
 message MessageDelete {


### PR DESCRIPTION
I tried to adhere to the guidlines for updating protobuf documents as described [here](https://developers.google.com/protocol-buffers/docs/overview#updating) to maintain backwards compatibility. Maybe we can allow ourselves to break some of them, but that depends on how clients handle the respective fields. Other than that, I tried to mimic the fields used by the new federation-aware endpoints.