### PR TITLE
Add new message types for QualifiedOtrNewMessage

### DIFF
--- a/proto/otr.proto
+++ b/proto/otr.proto
@@ -23,6 +23,7 @@ option java_package = "com.wire.messages";
 option java_outer_classname = "Otr";
 option optimize_for = LITE_RUNTIME;
 
+// deprecated, use QualifiedUserId
 message UserId {
     required bytes uuid = 1;
 }
@@ -41,18 +42,25 @@ message ClientEntry {
     required bytes    text   = 2;
 }
 
+// deprecated, use QualifiedUserEntry
 message UserEntry {
-    required UserId          user              = 1;
-    repeated ClientEntry     clients           = 2;
-    optional QualifiedUserId qualified_user_id = 3;
+    required UserId      user    = 1;
+    repeated ClientEntry clients = 2;
 }
 
+message QualifiedUserEntry {
+  required QualifiedUserId user = 1;
+  repeated ClientEntry clients = 2;
+}
+
+enum Priority {
+  // 0 is reserved for errors
+  LOW_PRIORITY = 1;
+  HIGH_PRIORITY = 2;
+};
+
+// deprecated, use QualifiedNewOtrMessage
 message NewOtrMessage {
-    enum Priority {
-      // 0 is reserved for errors
-      LOW_PRIORITY = 1;
-      HIGH_PRIORITY = 2;
-    };
     required ClientId  sender          = 1;
     repeated UserEntry recipients      = 2;
     optional bool      native_push     = 3 [default = true];
@@ -60,6 +68,36 @@ message NewOtrMessage {
     optional Priority  native_priority = 5;
     optional bool      transient       = 6;
     repeated UserId    report_missing  = 7;
+}
+
+message QualifiedNewOtrMessage {
+    required ClientId                  sender          = 1;
+    repeated QualifiedUserEntry        recipients      = 2;
+    optional bool                      native_push     = 3 [default = true];
+    optional bytes                     blob            = 4;
+    optional Priority                  native_priority = 5;
+    optional bool                      transient       = 6;
+    // For more details please refer to backend swagger at
+    // https://staging-nginz-https.zinfra.io/api/swagger-ui/
+    oneof client_mismatch_strategy {
+        ClientMismatchStrategy.ReportAll  report_all   = 7;
+        ClientMismatchStrategy.IgnoreAll  ignore_all   = 8;
+        ClientMismatchStrategy.ReportOnly report_only  = 9;
+        ClientMismatchStrategy.IgnoreOnly ignore_only  = 10;
+    }
+}
+
+message ClientMismatchStrategy {
+    message ReportAll {}
+    message IgnoreAll {}
+
+    message ReportOnly {
+        repeated QualifiedUserId user_ids = 1;
+    }
+
+    message IgnoreOnly {
+        repeated QualifiedUserId user_ids = 1;
+    }
 }
 
 message OtrAssetMeta {


### PR DESCRIPTION
This will be used for the new qualified endpoints which enable federation. The
old types are now marked deprecated.