### PR TITLE
feat: Add new InCallEmoji proto

### DIFF
--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -46,6 +46,7 @@ message GenericMessage {
     ButtonAction buttonAction = 21;
     ButtonActionConfirmation buttonActionConfirmation = 22;
     DataTransfer dataTransfer = 23; // client-side synchronization across devices of the same user
+    InCallEmoji inCallEmoji = 24;
   }
 }
 
@@ -329,6 +330,10 @@ message Reaction {
   optional string emoji = 1; // some emoji reaction or the empty string to remove previous reaction(s)
   required string message_id = 2;
   optional LegalHoldStatus legal_hold_status = 3 [default = UNKNOWN]; // whether this message was sent to legal hold
+}
+
+message InCallEmoji {
+  map<string, int32> emojis = 1;
 }
 
 message Calling {


### PR DESCRIPTION
# Add InCallEmoji Message for Live Emoji Reactions During Calls

## Description

This pull request introduces a new proto message type, `InCallEmoji`, to the `messages.proto` file. The `InCallEmoji` message will be used for sending live emoji reactions during a call in Wire. 

## Changes

- Added a new message type `InCallEmoji` to `proto/messages.proto`.
- `InCallEmoji` contains a map that allows for string keys (representing emoji names or identifiers) and integer values (representing the count of each emoji).

### New Proto Message

```proto
message InCallEmoji {
  map<string, int32> emojis = 1;
}
```