### PR TITLE
feat: add UnknownStrategy enum for future-proofing

### DIFF
--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -51,13 +51,13 @@ message GenericMessage {
     // Next field should be 26 ↓
   }
   optional UnknownStrategy unknownStrategy = 25 [default = IGNORE];
-}
 
-// See internal RFC: "2024-07-18 RFC Improve future-proofing for new OTR message types"
-enum UnknownStrategy {
-  IGNORE = 0;                 // Ignore the message completely. Trash. Bye
-  DISCARD_AND_WARN = 1;       // Warn the user, but discard the message, as it won't be helpful in the future.
-  WARN_USER_ALLOW_RETRY = 2;  // Warn the user. Client has freedom to store it and retry in the future.
+  // See internal RFC: "2024-07-18 RFC Improve future-proofing for new OTR message types"
+  enum UnknownStrategy {
+    IGNORE = 0;                 // Ignore the message completely. Trash. Bye
+    DISCARD_AND_WARN = 1;       // Warn the user, but discard the message, as it won't be helpful in the future.
+    WARN_USER_ALLOW_RETRY = 2;  // Warn the user. Client has freedom to store it and retry in the future.
+  }
 }
 
 message QualifiedUserId {

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -47,7 +47,17 @@ message GenericMessage {
     ButtonActionConfirmation buttonActionConfirmation = 22;
     DataTransfer dataTransfer = 23; // client-side synchronization across devices of the same user
     InCallEmoji inCallEmoji = 24;
+    // UnknownStrategy unknownStrategy = 25; -- Defined outside the oneof
+    // Next field should be 26 ↓
   }
+  optional UnknownStrategy unknownStrategy = 25 [default = IGNORE];
+}
+
+// See internal RFC: "2024-07-18 RFC Improve future-proofing for new OTR message types"
+enum UnknownStrategy {
+  IGNORE = 0;                 // Ignore the message completely. Trash. Bye
+  DISCARD_AND_WARN = 1;       // Warn the user, but discard the message, as it won't be helpful in the future.
+  WARN_USER_ALLOW_RETRY = 2;  // Warn the user. Client has freedom to store it and retry in the future.
 }
 
 message QualifiedUserId {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When introducing some message types, clients that are not ready to receive them yet might react in improper ways.

iOS warns about all received unknown messages while Android and Web ignore unknown message types.

This isn't currently unified between clients and there's no way of choosing a different approach depending on the newly introduced message type.

### Solutions

As proposed in the [internal RFC](https://wearezeta.atlassian.net/wiki/spaces/PAD/pages/1299546164/2024-07-18+RFC+Improve+future-proofing+for+new+OTR+message+types), add a new field called `unknownStrategy` to be sent beside the actual message content. If `content` is NULL/NONE, the `unknownStrategy` can give a hint of what to do and how to handle such message.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
