### PR TITLE
feat: add in call hand raise

### DIFF
--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -49,6 +49,7 @@ message GenericMessage {
     InCallEmoji inCallEmoji = 24;
     // UnknownStrategy unknownStrategy = 25; -- Defined outside the oneof
     // Next field should be 26 ↓
+    InCallHandRaise inCallHandRaise = 26;
   }
   optional UnknownStrategy unknownStrategy = 25 [default = IGNORE];
 
@@ -344,6 +345,10 @@ message Reaction {
 
 message InCallEmoji {
   map<string, int32> emojis = 1;
+}
+
+message InCallHandRaise {
+  required bool is_hand_up = 1; // true if the hand is raised, false if lowered
 }
 
 message Calling {


### PR DESCRIPTION
# Add InCallHandRaise Message for Hand Raise Feature During Calls

## Description

This pull request introduces a new proto message type, `InCallHandRaise`, to the `messages.proto` file. The `InCallHandRaise` message will support a live hand raise feature, allowing participants to raise and lower their hands during a call in Wire.

## Changes

- Added a new message type `InCallHandRaise` to `proto/messages.proto`.
- `InCallHandRaise` includes a boolean field, `is_hand_up`, to indicate if a participant’s hand is raised (`true`) or lowered (`false`).

### New Proto Message

```proto
message InCallHandRaise {
  required bool is_hand_up = 1;
}
