### PR TITLE
Migrate package publishing to GitHub Packages [WPB-26998]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,36 @@ on:
     branches: [master]
 
 permissions:
-  id-token: write
-  contents: write
+  contents: read
 
 jobs:
-  test_build_deploy:
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+
+      - name: "Set up Node.js for build and test"
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: "Build & Test"
+        run: yarn && yarn dist && yarn test
+
+  release:
+    name: Release package
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs:
+      - build-and-test
+    permissions:
+      contents: write
+      packages: write
     runs-on: ubuntu-latest
 
     steps:
@@ -20,36 +45,60 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "Set up Node.js (for build/test and npm publish)"
+      - name: "Set up Node.js for build"
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
-      - name: "Update npm to latest (Trusted Publishers requires npm >= 11.5.1)"
-        run: npm install -g npm@latest
-
-      - name: "Extend environment variables"
-        run: |
-          echo "BRANCH_NAME=$(git branch --show-current)" >> $GITHUB_ENV
-
-      - name: "Build & Test"
+      - name: "Build and test release contents"
         run: yarn && yarn dist && yarn test
 
-      # No npm token needed for publish; OIDC is handled automatically by npm Trusted Publishers
       - name: "Configure Git identity"
-        if: env.BRANCH_NAME == 'master'
         run: |
           git config --global user.email webapp+travis@wire.com
           git config --global user.name "Wire Travis CI"
 
+      - name: "Configure Node.js for GitHub Packages"
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@wireapp"
+
+      - name: "Publish current version if missing from GitHub Packages"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PACKAGE_NAME="$(node -p "require('./package.json').name")"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          PACKAGE_REFERENCE="${PACKAGE_NAME}@${PACKAGE_VERSION}"
+
+          if npm view \
+            "$PACKAGE_REFERENCE" \
+            version \
+            --registry=https://npm.pkg.github.com \
+            >/dev/null 2>&1; then
+            echo "📦 ${PACKAGE_REFERENCE} already exists in GitHub Packages."
+            exit 0
+          fi
+
+          echo "📦 Publishing existing ${PACKAGE_REFERENCE} to GitHub Packages..."
+          npm publish --registry=https://npm.pkg.github.com
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Release new version"
-        if: env.BRANCH_NAME == 'master'
         run: yarn version --minor
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-ios-spm-tests:
     name: Test Swift package on macOS
     runs-on: macos-26
+    permissions:
+      contents: read
 
     steps:
       - name: Install swift-protobuf

--- a/docs/package-publishing.md
+++ b/docs/package-publishing.md
@@ -1,0 +1,50 @@
+# Package publishing
+
+`@wireapp/protocol-messaging` is published to the GitHub Packages npm registry at `https://npm.pkg.github.com`.
+
+## Release lifecycle
+
+The `master` workflow installs dependencies from npmjs.com, builds the package, and runs its tests. On a successful push to `master`, the existing Yarn lifecycle continues to:
+
+1. Run `yarn version --minor`.
+2. Push the version commit and tag to `master`.
+3. Publish the package through the `postversion` script.
+
+The package manifest targets GitHub Packages through `publishConfig`. Workflow permissions default to `contents: read`: the build-and-test and Swift jobs use read-only repository access. Only the release job runs for a push to `master` and receives `contents: write` to push the version commit and tags and `packages: write` to publish the package. It authenticates publication with the repository-provided `GITHUB_TOKEN`.
+
+Before creating the next minor version, the migration workflow reads the package name and current version from `package.json` and checks whether that exact version exists in GitHub Packages. It publishes the current version only when it is missing. This backfills `1.56.0` for `wireapp/wire-webapp`, which depends on that exact version. Future releases skip the backfill when the current version already exists, while still allowing a retry when a previous release committed a version but did not publish it.
+
+Pull requests only build and test, with read-only permissions. They cannot publish packages, push commits, or create tags. The Swift package tests also use read-only repository access.
+
+The npmjs.com Trusted Publisher configuration and OIDC publication are no longer used. Remove the obsolete npmjs.com configuration after the GitHub Packages migration has been confirmed.
+
+## Local installation
+
+To install the package locally, authenticate to GitHub Packages with a GitHub personal access token (classic) that has `read:packages`:
+
+```bash
+npm login \
+  --scope=@wireapp \
+  --auth-type=legacy \
+  --registry=https://npm.pkg.github.com
+```
+
+Current npm versions otherwise use a browser-oriented login flow. GitHub Packages requires entering your GitHub username and a personal access token (classic) with `read:packages` as the password. Alternatively, configure an environment-backed token in your user-level npm configuration:
+
+```ini
+@wireapp:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_TOKEN}
+```
+
+Do not put tokens or other credentials in version control.
+
+## Required GitHub configuration after the first publication
+
+After the first GitHub Packages publication:
+
+1. Confirm that the package is associated with `wireapp/generic-message-proto`.
+2. Set or verify the intended package visibility.
+3. In the package’s Actions access settings, explicitly grant `wireapp/wire-webapp` read access when required.
+4. Verify that the `wireapp/wire-webapp` workflow can read the exact version `@wireapp/protocol-messaging@1.56.0`.
+
+The cross-repository migration is not complete until this access is configured and the exact version is verified from the `wireapp/wire-webapp` workflow.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "license": "GPL-3.0",
   "description": "Protocol definition for generic messages.",
   "repository": "https://github.com/wireapp/generic-message-proto.git",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "files": [
     "proto/*.proto",
     "web/*.d.ts",


### PR DESCRIPTION
This pull request migrates `@wireapp/protocol-messaging` from npmjs.com to the GitHub Packages npm registry.

The existing Yarn versioning lifecycle remains in place. Publication now uses the repository’s `GITHUB_TOKEN` with `packages: write`, and the package manifest explicitly targets `https://npm.pkg.github.com`.

The npmjs.com Trusted Publisher and OIDC configuration are no longer required.

## Preserve the current package version

`wireapp/wire-webapp` currently depends on the exact version:

```json
"@wireapp/protocol-messaging": "1.56.0"
```

The existing release workflow creates the next minor version through `yarn version --minor`. Simply changing the publication registry would therefore publish `1.57.0` while leaving `1.56.0` available only from npmjs.com.

Before creating the next minor release, the workflow now checks whether the current package version exists in GitHub Packages. It publishes that version when missing and skips the step when it is already available.

This keeps the migration idempotent and also allows a later workflow run to recover when a version was committed but its publication failed.

## Relationship to wire-webapp

This pull request is a prerequisite for https://github.com/wireapp/wire-webapp/pull/21813.

After the first publication, the GitHub package settings must grant `wireapp/wire-webapp` read access where required. Its publishing workflow verifies that the exact required `@wireapp/protocol-messaging` version is available before publishing `@wireapp/api-client`.